### PR TITLE
Allow debugging when blender is running headlessly

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,13 +123,13 @@ Now in Blender the text editor will show this little red button in the top left.
 
 ### Debugging Blender running via command line
 
-Ensure that the addon is installed, enabled and attempts to connect to the debugging server in the script passed as an argument to Blender. 
+In your script that will be executed by Blender, ensure that the addon is installed, enabled and attempts to connect to the debugging server
 
 In a terminal, call for Blender to execute your script with the flags `-b -P` or `-b --python`. More information can be found here [Blender Command Line Mode](https://docs.blender.org/manual/en/latest/advanced/command_line/introduction.html)
 
-Once this script executes, it will await a connection to be made to the debugging server. Once this is established, the script will continue executing and VSCode should pause on breakpoints that have been triggered.
+This script will execute and then await a connection to be made to the debugging server. Once this is established, the script will continue executing and VSCode should pause on breakpoints that have been triggered.
 
-Note: You can use bpy.app.background to identify when Blender is running in the background.
+Note: The addon is using the bpy.app.background boolean to identify when Blender is running in the background.
 
 # Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,16 @@ Now in Blender the text editor will show this little red button in the top left.
 	See [Issue #4](https://github.com/AlansCodeLog/blender-debugger-for-vscode/issues/4) for a workaround.
 	In the future if I have some time, I might see if there's something I can do to make this easier.
 
+### Debugging Blender running via command line
+
+Ensure that the addon is installed, enabled and attempts to connect to the debugging server in the script passed as an argument to Blender. 
+
+In a terminal, call for Blender to execute your script with the flags `-b -P` or `-b --python`. More information can be found here [Blender Command Line Mode](https://docs.blender.org/manual/en/latest/advanced/command_line/introduction.html)
+
+Once this script executes, it will await a connection to be made to the debugging server. Once this is established, the script will continue executing and VSCode should pause on breakpoints that have been triggered.
+
+Note: You can use bpy.app.background to identify when Blender is running in the background.
+
 # Troubleshooting
 
 - Check you installed the correct debugpy version. With VS Code this should no longer be an issue, but I believe different versions of Visual Studio need different versions of debugpy (see [Installing Python Support](https://docs.microsoft.com/en-us/visualstudio/python/installing-python-support-in-visual-studio)).

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ In a terminal, call for Blender to execute your script with the flags `-b -P you
 
 This script will execute and then await a connection to be made to the debugging server. Once this is established, the script will continue executing and VSCode should pause on breakpoints that have been triggered.
 
-Note: The addon is using the bpy.app.background boolean to identify when Blender is running in the background.
+Note: The addon is using the bpy.app.background boolean to identify when Blender is running in the background but it accepts a waitForClient property to force us to await the connection.
 
 # Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ Now in Blender the text editor will show this little red button in the top left.
 
 ### Debugging Blender running via command line
 
-In your script that will be executed by Blender, ensure that the addon is installed, enabled and attempts to connect to the debugging server
+In your script that will be executed by Blender, ensure that the addon is installed, enabled and attempts to connect to the debugging server.
 
-In a terminal, call for Blender to execute your script with the flags `-b -P` or `-b --python`. More information can be found here [Blender Command Line Mode](https://docs.blender.org/manual/en/latest/advanced/command_line/introduction.html)
+In a terminal, call for Blender to execute your script with the flags `-b -P your_script.py` or `-b --python your_script.py`. More information can be found here [Blender Command Line Mode](https://docs.blender.org/manual/en/latest/advanced/command_line/introduction.html)
 
 This script will execute and then await a connection to be made to the debugging server. Once this is established, the script will continue executing and VSCode should pause on breakpoints that have been triggered.
 

--- a/__init__.py
+++ b/__init__.py
@@ -166,6 +166,8 @@ class DebugServerStart(bpy.types.Operator):
    bl_label = "Debug: Start Debug Server for VS Code"
    bl_description = "Starts debugpy server for debugger to attach to"
    
+   waitForClient: bpy.props.BoolProperty(default=False)
+
    def execute(self, context):
       #get debugpy and import if exists
       prefs = bpy.context.preferences.addons[__name__].preferences
@@ -193,7 +195,7 @@ class DebugServerStart(bpy.types.Operator):
       except:
          print("Server already running.")
 
-      if (bpy.app.background):
+      if (bpy.app.background or self.waitForClient):
          self.report({"INFO"}, "Ready to connect")
          debugpy.wait_for_client()
 

--- a/__init__.py
+++ b/__init__.py
@@ -166,6 +166,8 @@ class DebugServerStart(bpy.types.Operator):
    bl_label = "Debug: Start Debug Server for VS Code"
    bl_description = "Starts debugpy server for debugger to attach to"
 
+   isBackgroundMode : bpy.props.BoolProperty(default=False)
+   
    def execute(self, context):
       #get debugpy and import if exists
       prefs = bpy.context.preferences.addons[__name__].preferences
@@ -193,6 +195,9 @@ class DebugServerStart(bpy.types.Operator):
       except:
          print("Server already running.")
 
+      if (self.isBackgroundMode):
+         debugpy.wait_for_client()
+         
       # call our confirmation listener
       bpy.ops.debug.check_for_debugger()
       return {"FINISHED"}

--- a/__init__.py
+++ b/__init__.py
@@ -166,6 +166,8 @@ class DebugServerStart(bpy.types.Operator):
    bl_label = "Debug: Start Debug Server for VS Code"
    bl_description = "Starts debugpy server for debugger to attach to"
 
+   isBackgroundMode : bpy.props.BoolProperty(default=False)
+
    def execute(self, context):
       #get debugpy and import if exists
       prefs = bpy.context.preferences.addons[__name__].preferences
@@ -192,6 +194,9 @@ class DebugServerStart(bpy.types.Operator):
          debugpy.listen(("localhost", debugpy_port))
       except:
          print("Server already running.")
+
+      if (self.isBackgroundMode):
+         debugpy.wait_for_client()
 
       # call our confirmation listener
       bpy.ops.debug.check_for_debugger()

--- a/__init__.py
+++ b/__init__.py
@@ -21,7 +21,7 @@ Created by Alan North
 bl_info = {
    'name': 'Debugger for VS Code',
    'author': 'Alan North',
-   'version': (2, 0, 0),
+   'version': (2, 1, 0),
    'blender': (2, 80, 0), # supports 2.8+
    "description": "Starts debugging server for VS Code.",
    'location': 'In search (Edit > Operator Search) type "Debug"',
@@ -166,13 +166,13 @@ class DebugServerStart(bpy.types.Operator):
    bl_label = "Debug: Start Debug Server for VS Code"
    bl_description = "Starts debugpy server for debugger to attach to"
 
-   isBackgroundMode : bpy.props.BoolProperty(default=False)
-
    def execute(self, context):
       #get debugpy and import if exists
       prefs = bpy.context.preferences.addons[__name__].preferences
       debugpy_path = prefs.path.rstrip("/")
       debugpy_port = prefs.port
+
+      waitForClient: bpy.props.BoolProperty(default=False)
 
       #actually check debugpy is still available
       if debugpy_path == "debugpy not found":
@@ -195,7 +195,8 @@ class DebugServerStart(bpy.types.Operator):
       except:
          print("Server already running.")
 
-      if (self.isBackgroundMode):
+      if (self.waitForClient):
+         self.report({"INFO"}, "Ready to connect")
          debugpy.wait_for_client()
 
       # call our confirmation listener

--- a/__init__.py
+++ b/__init__.py
@@ -196,6 +196,7 @@ class DebugServerStart(bpy.types.Operator):
          print("Server already running.")
 
       if (self.isBackgroundMode):
+         self.report({"INFO"}, "Ready for connection")
          debugpy.wait_for_client()
          
       # call our confirmation listener

--- a/__init__.py
+++ b/__init__.py
@@ -172,8 +172,6 @@ class DebugServerStart(bpy.types.Operator):
       debugpy_path = prefs.path.rstrip("/")
       debugpy_port = prefs.port
 
-      waitForClient: bpy.props.BoolProperty(default=False)
-
       #actually check debugpy is still available
       if debugpy_path == "debugpy not found":
          self.report({"ERROR"}, "Couldn't detect debugpy, please specify the path manually in the addon preferences or reload the addon if you installed debugpy after enabling it.")
@@ -195,7 +193,7 @@ class DebugServerStart(bpy.types.Operator):
       except:
          print("Server already running.")
 
-      if (self.waitForClient):
+      if (bpy.app.background):
          self.report({"INFO"}, "Ready to connect")
          debugpy.wait_for_client()
 


### PR DESCRIPTION
Adding a check for to determine whether Blender is running through the command line or through the GUI. Lets users debug Blender when its running in a pipeline or any tests they've written for their addon